### PR TITLE
Favorites add and remove

### DIFF
--- a/api/src/index.mjs
+++ b/api/src/index.mjs
@@ -11,6 +11,7 @@ import usersRouter from "./routers/users.js";
 import toursRouter from "./routers/tours.js";
 import healthCheckRoute from "./routers/healthCheck.mjs";
 import morgan from "morgan";
+import favoritesRouter from "./routers/favorites.js";
 
 const app = express();
 app.use(cors());
@@ -59,6 +60,9 @@ app.use("/api", apiRouter);
 
 // global error handler
 app.use(errorHandler);
+
+// favorites add, remove
+app.use("/api/favorites", favoritesRouter);
 
 app.listen(process.env.PORT, () => {
   console.log(`API listening on port ${process.env.PORT}`);

--- a/api/src/routers/favorites.js
+++ b/api/src/routers/favorites.js
@@ -1,0 +1,102 @@
+import express from "express";
+import knex from "../db.mjs";
+import { favoriteSchema } from "../validation/schemas.js";
+import { validateRequest } from "../middleware/validation.js";
+import { authenticateToken } from "../middleware/auth.js";
+
+const favoritesRouter = express.Router();
+
+// Apply authentication to all routes in this file.
+favoritesRouter.use(authenticateToken);
+
+// Helper to check if the item being favorited actually exists in the database.
+const itemExists = async (item_id, item_type) => {
+  let tableName;
+  switch (item_type) {
+    case "tour":
+      tableName = "travel_plans";
+      break;
+    case "post":
+      tableName = "user_posts";
+      break;
+    case "attraction":
+      tableName = "attraction_posts";
+      break;
+    default:
+      return false;
+  }
+  const item = await knex(tableName).where({ id: item_id }).first();
+  return !!item; // Returns true if item is found, false otherwise.
+};
+
+// POST /api/favorites - Add a new favorite
+favoritesRouter.post("/", validateRequest(favoriteSchema), async (req, res) => {
+  try {
+    const userId = req.user.id || req.user.sub;
+    const { item_id, item_type } = req.validatedData;
+
+    // Verify that the item the user is trying to favorite actually exists.
+    if (!(await itemExists(item_id, item_type))) {
+      return res.status(404).json({
+        error: "Not Found",
+        message: "The item you are trying to favorite does not exist.",
+      });
+    }
+
+    const [newFavorite] = await knex("user_favorites")
+      .insert({ user_id: userId, item_id, item_type })
+      .returning("*");
+
+    res.status(201).json({
+      message: `Successfully added ${item_type} to your favorites.`,
+      data: newFavorite,
+    });
+  } catch (error) {
+    console.error("Error adding favorite:", error);
+    if (error.code === "23505") {
+      // Unique constraint violation
+      return res.status(409).json({
+        error: "Already favorited",
+        message: "You have already added this item to your favorites.",
+      });
+    }
+    res.status(500).json({
+      error: "Favorite submission failed",
+      message:
+        "We encountered an error while adding this item to your favorites.",
+    });
+  }
+});
+
+// DELETE /api/favorites/:itemId - Remove a favorite
+favoritesRouter.delete("/:itemId", async (req, res) => {
+  try {
+    const userId = req.user.id || req.user.sub;
+    const { itemId } = req.params;
+
+    // The .where clause ensures a user can only delete their own favorites.
+    const count = await knex("user_favorites")
+      .where({ user_id: userId, item_id: itemId })
+      .del();
+
+    if (count === 0) {
+      return res.status(404).json({
+        error: "Not Found",
+        message: "This item was not found in your favorites.",
+      });
+    }
+
+    res
+      .status(200)
+      .json({ message: "Item successfully removed from your favorites." });
+  } catch (error) {
+    console.error("Error removing favorite:", error);
+    res.status(500).json({
+      error: "Favorite removal failed",
+      message:
+        "We encountered an error while removing this item from your favorites.",
+    });
+  }
+});
+
+export default favoritesRouter;

--- a/api/src/validation/schemas.js
+++ b/api/src/validation/schemas.js
@@ -187,3 +187,13 @@ export const commentSchema = z.object({
     .min(1, "Comment content is required.")
     .max(500, "Comment cannot be more than 500 characters long."),
 });
+
+// Schema for adding a new favorite
+export const favoriteSchema = z.object({
+  item_id: z.string().uuid("A valid item ID is required."),
+  item_type: z.enum(["tour", "post", "attraction"], {
+    required_error: "Item type is required.",
+    invalid_type_error:
+      "Item type must be one of 'tour', 'post', or 'attraction'.",
+  }),
+});

--- a/postman/postman_collection.json
+++ b/postman/postman_collection.json
@@ -1,0 +1,795 @@
+{
+	"info": {
+		"_postman_id": "a1b2c3d4-e5f6-4a3b-8c7d-9f0e1d2c3b4a",
+		"name": "Travel Planner API",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "Authentication",
+			"item": [
+				{
+					"name": "Register New User",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									"// This script runs before the request is sent.",
+									"// It generates a unique username and email for the new user.",
+									"const randomSuffix = Math.random().toString(36).substring(2, 10);",
+									"pm.collectionVariables.set(\"new_user_username\", `testuser_${randomSuffix}`);",
+									"pm.collectionVariables.set(\"new_user_email\", `testuser_${randomSuffix}@example.com`);",
+									"pm.collectionVariables.set(\"new_user_password\", \"SecurePass123\");"
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"// This script runs after a successful registration.",
+									"// It automatically saves the new user's ID and JWT token.",
+									"if (pm.response.code === 201) {",
+									"    const response = pm.response.json();",
+									"    if (response.user && response.user.id) {",
+									"        pm.collectionVariables.set(\"userId\", response.user.id);",
+									"        console.log(`User ID ${response.user.id} saved successfully!`);",
+									"    }",
+									"    if (response.token) {",
+									"        pm.collectionVariables.set(\"jwt_token\", response.token);",
+									"        console.log(\"JWT Token from registration saved successfully!\");",
+									"    }",
+									"}"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "noauth"
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"first_name\": \"{{$randomFirstName}}\",\n    \"last_name\": \"{{$randomLastName}}\",\n    \"email\": \"{{new_user_email}}\",\n    \"username\": \"{{new_user_username}}\",\n    \"password\": \"{{new_user_password}}\",\n    \"password_confirmation\": \"{{new_user_password}}\",\n    \"mobile\": \"{{$randomPhoneNumber}}\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseUrl}}/api/auth/register",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"api",
+								"auth",
+								"register"
+							]
+						},
+						"description": "Creates a new user account with dynamic credentials and saves them for the Login request."
+					},
+					"response": []
+				},
+				{
+					"name": "Login User",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"if (pm.response.code === 200) {",
+									"    const response = pm.response.json();",
+									"    if (response.token) {",
+									"        pm.collectionVariables.set(\"jwt_token\", response.token);",
+									"        console.log(\"JWT Token saved successfully!\");",
+									"    }",
+									"}"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "noauth"
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"login_identifier\": \"{{new_user_email}}\",\n    \"password\": \"{{new_user_password}}\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseUrl}}/api/auth/login",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"api",
+								"auth",
+								"login"
+							]
+						},
+						"description": "Logs in a user and saves the JWT token for all other requests. Uses credentials from the last registered user."
+					},
+					"response": []
+				}
+			],
+			"description": "Endpoints for user registration and login."
+		},
+		{
+			"name": "User",
+			"item": [
+				{
+					"name": "Get User Profile",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/api/users/profile",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"api",
+								"users",
+								"profile"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Update Profile",
+					"request": {
+						"method": "PUT",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"first_name\": \"John\",\n    \"last_name\": \"Smith\",\n    \"mobile\": \"+1987654321\",\n    \"profile_image\": \"https://example.com/avatar.jpg\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseUrl}}/api/users/profile",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"api",
+								"users",
+								"profile"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Change Password",
+					"request": {
+						"method": "PUT",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"current_password\": \"SecurePass123\",\n    \"new_password\": \"NewSecurePass456\",\n    \"new_password_confirmation\": \"NewSecurePass456\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseUrl}}/api/users/change-password",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"api",
+								"users",
+								"change-password"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "Favorites",
+			"item": [
+				{
+					"name": "Add a Favorite",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"item_id\": \"{{tourId}}\",\n    \"item_type\": \"tour\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseUrl}}/api/favorites",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"api",
+								"favorites"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Remove a Favorite",
+					"request": {
+						"method": "DELETE",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/api/favorites/{{tourId}}",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"api",
+								"favorites",
+								"{{tourId}}"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "Posts",
+			"item": [
+				{
+					"name": "Create New Post",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"// This script runs after a successful post creation.",
+									"// It automatically saves the new post's ID to a variable.",
+									"if (pm.response.code === 201) {",
+									"    const response = pm.response.json();",
+									"    if (response.data && response.data.id) {",
+									"        pm.collectionVariables.set(\"postId\", response.data.id);",
+									"        console.log(`Post ID ${response.data.id} saved successfully!`);",
+									"    }",
+									"}"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"title\": \"My First Post\",\n    \"content\": \"This is the content of my first post.\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseUrl}}/api/posts",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"api",
+								"posts"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Post Comments",
+					"item": [
+						{
+							"name": "Get All Comments for a Post",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/api/posts/{{postId}}/comments",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"api",
+										"posts",
+										"{{postId}}",
+										"comments"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Create New Comment",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"// This script runs after a successful comment creation.",
+											"// It automatically saves the new comment's ID to a variable.",
+											"if (pm.response.code === 201) {",
+											"    const response = pm.response.json();",
+											"    if (response.data && response.data.id) {",
+											"        pm.collectionVariables.set(\"commentId\", response.data.id);",
+											"        console.log(`Comment ID ${response.data.id} saved successfully!`);",
+											"    }",
+											"}"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"content\": \"This is a fantastic and insightful article!\"\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/api/posts/{{postId}}/comments",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"api",
+										"posts",
+										"{{postId}}",
+										"comments"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Update Existing Comment",
+							"request": {
+								"method": "PUT",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"content\": \"This is my updated comment with some new thoughts.\"\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/api/posts/{{postId}}/comments/{{commentId}}",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"api",
+										"posts",
+										"{{postId}}",
+										"comments",
+										"{{commentId}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Delete a Comment",
+							"request": {
+								"method": "DELETE",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/api/posts/{{postId}}/comments/{{commentId}}",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"api",
+										"posts",
+										"{{postId}}",
+										"comments",
+										"{{commentId}}"
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Tours",
+			"item": [
+				{
+					"name": "Get All Tours",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/api/tours?search=europe&sort=price-desc&page=1",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"api",
+								"tours"
+							],
+							"query": [
+								{
+									"key": "search",
+									"value": "europe",
+									"description": "Search term for tour name, description, or destination."
+								},
+								{
+									"key": "sort",
+									"value": "price-desc",
+									"description": "Sort order: price-asc, price-desc, rating-desc, name-asc, etc."
+								},
+								{
+									"key": "page",
+									"value": "1"
+								},
+								{
+									"key": "limit",
+									"value": "9",
+									"disabled": true
+								},
+								{
+									"key": "minPrice",
+									"value": "100000",
+									"description": "Minimum price in minor units (e.g., cents).",
+									"disabled": true
+								},
+								{
+									"key": "maxPrice",
+									"value": "500000",
+									"disabled": true
+								},
+								{
+									"key": "minDuration",
+									"value": "7",
+									"description": "Minimum duration in days.",
+									"disabled": true
+								},
+								{
+									"key": "maxDuration",
+									"value": "14",
+									"disabled": true
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get Single Tour",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/api/tours/{{tourId}}",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"api",
+								"tours",
+								"{{tourId}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Create New Tour",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"// This script runs after a successful tour creation.",
+									"// It automatically saves the new tour's ID to a variable.",
+									"if (pm.response.code === 201) {",
+									"    const response = pm.response.json();",
+									"    const tourData = response.data || response.tour;",
+									"    if (tourData && tourData.id) {",
+									"        pm.collectionVariables.set(\"tourId\", tourData.id);",
+									"        console.log(`Tour ID ${tourData.id} saved successfully!`);",
+									"    }",
+									"}"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"name\": \"Asian Capitals Explorer\",\n    \"description\": \"A whirlwind tour of Asia's most vibrant capital cities.\",\n    \"start_date\": \"2026-07-15\",\n    \"duration_days\": 12,\n    \"price_minor\": 350000,\n    \"currency_code\": \"USD\",\n    \"capacity\": 18,\n    \"cover_image_url\": \"https://placehold.co/600x400/1a1a1a/ffffff?text=Asia+Explorer\",\n    \"destinations\": [\n        {\n            \"city_name\": \"Tokyo\",\n            \"country_name\": \"Japan\",\n            \"duration_days\": 4\n        },\n        {\n            \"city_name\": \"Seoul\",\n            \"country_name\": \"South Korea\",\n            \"duration_days\": 4\n        },\n        {\n            \"city_name\": \"Bangkok\",\n            \"country_name\": \"Thailand\",\n            \"duration_days\": 4\n        }\n    ]\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseUrl}}/api/tours",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"api",
+								"tours"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Update Existing Tour",
+					"request": {
+						"method": "PUT",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"name\": \"Updated Tour Name\",\n    \"price_minor\": 400000\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseUrl}}/api/tours/{{tourId}}",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"api",
+								"tours",
+								"{{tourId}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Delete a Tour",
+					"request": {
+						"method": "DELETE",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/api/tours/{{tourId}}",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"api",
+								"tours",
+								"{{tourId}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Tour Reviews",
+					"item": [
+						{
+							"name": "Get All Reviews for a Tour",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/api/tours/{{tourId}}/reviews",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"api",
+										"tours",
+										"{{tourId}}",
+										"reviews"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Create New Review",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"// This script runs after a successful review creation.",
+											"// It automatically saves the new review's ID to a variable.",
+											"if (pm.response.code === 201) {",
+											"    const response = pm.response.json();",
+											"    if (response.data && response.data.id) {",
+											"        pm.collectionVariables.set(\"reviewId\", response.data.id);",
+											"        console.log(`Review ID ${response.data.id} saved successfully!`);",
+											"    }",
+											"}"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"rating\": 5,\n    \"content\": \"This tour was an amazing experience from start to finish!\"\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/api/tours/{{tourId}}/reviews",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"api",
+										"tours",
+										"{{tourId}}",
+										"reviews"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Update Existing Review",
+							"request": {
+								"method": "PUT",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"rating\": 4,\n    \"content\": \"This is my updated review. It was still a great tour, but one day was a bit rushed.\"\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/api/tours/{{tourId}}/reviews/{{reviewId}}",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"api",
+										"tours",
+										"{{tourId}}",
+										"reviews",
+										"{{reviewId}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Delete a Review",
+							"request": {
+								"method": "DELETE",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/api/tours/{{tourId}}/reviews/{{reviewId}}",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"api",
+										"tours",
+										"{{tourId}}",
+										"reviews",
+										"{{reviewId}}"
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				}
+			]
+		}
+	],
+	"auth": {
+		"type": "bearer",
+		"bearer": [
+			{
+				"key": "token",
+				"value": "{{jwt_token}}",
+				"type": "string"
+			}
+		]
+	},
+	"variable": [
+		{
+			"key": "baseUrl",
+			"value": "http://localhost:3001"
+		},
+		{
+			"key": "jwt_token",
+			"value": ""
+		},
+		{
+			"key": "tourId",
+			"value": "713eb327-468a-48c9-babf-883bb27d4d6e"
+		},
+		{
+			"key": "postId",
+			"value": "ea28750f-e4b3-46df-8d9c-9fc3f15bec6b"
+		},
+		{
+			"key": "reviewId",
+			"value": ""
+		},
+		{
+			"key": "commentId",
+			"value": ""
+		},
+		{
+			"key": "userId",
+			"value": ""
+		},
+		{
+			"key": "new_user_email",
+			"value": ""
+		},
+		{
+			"key": "new_user_password",
+			"value": ""
+		},
+		{
+			"key": "new_user_username",
+			"value": ""
+		}
+	]
+}
+


### PR DESCRIPTION
Implemented the POST /api/favorites and DELETE /api/favorites/:itemId endpoints, allowing authenticated users to add and remove items (tours, posts, attractions) from their favorites.

I also added a postman collection to speedup router testing

How to Use it:

Pull down the latest changes from this branch.

Import the collection from /postman/postman_collection.json into your Postman client.

Run the Login User request to get an authentication token.

Then send any request you wish from the list of requests. you don't need to fill the body or authentication details, it is automatic.